### PR TITLE
Fixing an issue with GetSaltFromPass

### DIFF
--- a/enc_posix.cpp
+++ b/enc_posix.cpp
@@ -22,11 +22,17 @@ class EPosix : public Module
 
         /* splits the appended salt from the password string so it can be used for the next encryption */
         /* password format:  <hashmethod>:<password>:<salt> */
-	void GetSaltFromPass(const Anope::string &password)
+	bool GetSaltFromPass(const Anope::string &password)
 	{
 		size_t pos = password.find("$");
+		if (pos == Anope::string::npos)
+			return false;
 		size_t pos2 = password.find("$", pos + 1);
+		if (pos2 == Anope::string::npos)
+			return false;
 		size_t pos3 = password.find("$", pos2 + 1);
+		if (pos3 == Anope::string::npos)
+			return false;
 
 		std::stringstream buf;
 
@@ -36,6 +42,7 @@ class EPosix : public Module
 			buf << "$1$replaceme";
 
 		salt = buf.str();
+		return true;
 	}
 
  public:


### PR DESCRIPTION
Upon debugging I found that the GetSaltFromPass function caused Anope to crash if faced with a password that does not match the format specified. In order to prevent a crash the simple error catcher from the function called directly above GetSaltFromPass was applied. If faced with an unconverted or false format password it will now no longer crash but instead print out "Password incorrect." and services will not crash. NOTE: This is not true error handling, this is simply preventing a crash. PS. I did the debugging and the error report, the C++ was done by Adam.
